### PR TITLE
Add image syncing to remote hosts.

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/elephant_vending_machine/__init__.py
+++ b/elephant_vending_machine/__init__.py
@@ -7,6 +7,11 @@ resolve to the correct package.
 from flask import Flask
 
 APP = Flask(__name__)
+APP.config.update(
+    REMOTE_HOSTS = ['192.168.1.11', '192.168.1.12', '192.168.1.13'],
+    REMOTE_HOST_USERNAME = 'pi',
+    REMOTE_IMAGE_DIRECTORY = '~/elephant_vending_machine/images'
+)
 
 # Circular imports are bad, but views are not used here, only imported, so it's OK
 # pylint: disable=wrong-import-position

--- a/elephant_vending_machine/__init__.py
+++ b/elephant_vending_machine/__init__.py
@@ -8,9 +8,9 @@ from flask import Flask
 
 APP = Flask(__name__)
 APP.config.update(
-    REMOTE_HOSTS = ['192.168.1.11', '192.168.1.12', '192.168.1.13'],
-    REMOTE_HOST_USERNAME = 'pi',
-    REMOTE_IMAGE_DIRECTORY = '~/elephant_vending_machine/images'
+    REMOTE_HOSTS=['192.168.1.11', '192.168.1.12', '192.168.1.13'],
+    REMOTE_HOST_USERNAME='pi',
+    REMOTE_IMAGE_DIRECTORY='~/elephant_vending_machine/images'
 )
 
 # Circular imports are bad, but views are not used here, only imported, so it's OK

--- a/elephant_vending_machine/views.py
+++ b/elephant_vending_machine/views.py
@@ -9,6 +9,8 @@ a lot of routes.
 # pylint: disable=cyclic-import
 from datetime import datetime
 import os
+import subprocess
+from subprocess import CalledProcessError
 from flask import request
 from werkzeug.utils import secure_filename
 from elephant_vending_machine import APP
@@ -43,8 +45,29 @@ def run_trial():
         response = 'No trial_name specified'
     return response
 
+def add_remote_image(local_image_path, filename):
+    """Adds an image to the remote hosts defined in flask config.
+
+    Parameters:
+        local_image_path (str): The local path of the image to be copied
+        filename (str): The filename of the local file to be copied
+
+    Raises:
+        CalledProcessError: If scp or ssh calls fail for one of the hosts
+    """
+    for host in APP.config['REMOTE_HOSTS']:
+        user = APP.config['REMOTE_HOST_USERNAME']
+        directory = APP.config['REMOTE_IMAGE_DIRECTORY']
+        ssh_command = f"ssh {user}@{host} mkdir -p {directory}"
+        subprocess.run(ssh_command, check=True)
+        scp_command = f"scp {local_image_path}/{filename} {user}@{host}:{directory}/{filename}"
+        subprocess.run(scp_command, check=True)
+
 def allowed_file(filename):
     """Determines whether an uploaded image file has an allowed extension.
+
+    Parameters:
+        filename (str): The filename which is to be checked
 
     Returns:
         True if filename includes extension and extension is an allowed extension
@@ -108,11 +131,17 @@ def upload_image():
             file.save(os.path.join(save_path, filename))
             response = "Success: Image saved."
             response_code = 201
+
+            try:
+                add_remote_image(save_path, filename)
+            except CalledProcessError:
+                response = "Error: Failed to copy file to hosts"
+                response_code = 400
         else:
             response = "Error with request: File extension not allowed."
     return response, response_code
 
-
+APP.config['REMOTE_IMAGE_DIRECTORY']
 @APP.route('/log', methods=['GET'])
 def log():
     """Returns the specified log file

--- a/elephant_vending_machine/views.py
+++ b/elephant_vending_machine/views.py
@@ -136,7 +136,7 @@ def upload_image():
                 add_remote_image(save_path, filename)
             except CalledProcessError:
                 response = "Error: Failed to copy file to hosts"
-                response_code = 400
+                response_code = 500
         else:
             response = "Error with request: File extension not allowed."
     return response, response_code

--- a/elephant_vending_machine/views.py
+++ b/elephant_vending_machine/views.py
@@ -141,7 +141,6 @@ def upload_image():
             response = "Error with request: File extension not allowed."
     return response, response_code
 
-APP.config['REMOTE_IMAGE_DIRECTORY']
 @APP.route('/log', methods=['GET'])
 def log():
     """Returns the specified log file

--- a/tests/view_tests/test_image_routes.py
+++ b/tests/view_tests/test_image_routes.py
@@ -2,6 +2,10 @@ import pytest
 from io import BytesIO
 
 from elephant_vending_machine import elephant_vending_machine
+from subprocess import CompletedProcess, CalledProcessError
+
+def raise_(ex):
+    raise ex
 
 @pytest.fixture
 def client():
@@ -9,7 +13,6 @@ def client():
 
     with elephant_vending_machine.APP.test_client() as client:
         yield client
-
 
 def test_post_image_route_no_file(client):
     response = client.post('/image')
@@ -30,7 +33,16 @@ def test_post_image_route_with_file_bad_extension(client):
 
 def test_post_image_route_with_file(monkeypatch, client):
     monkeypatch.setattr('werkzeug.datastructures.FileStorage.save', lambda save_path, filename: "" )
+    monkeypatch.setattr('subprocess.run', lambda command, check: CompletedProcess(['some_command'], returncode=0))
     data = {'file': (BytesIO(b"Testing: \x00\x01"), 'test_file.png')}
     response = client.post('/image', data=data) 
     assert response.status_code == 201
     assert b'Success: Image saved.' in response.data
+
+def test_post_image_route_copying_exception(monkeypatch, client):
+    monkeypatch.setattr('werkzeug.datastructures.FileStorage.save', lambda save_path, filename: "" )
+    monkeypatch.setattr('subprocess.run', lambda command, check: raise_(CalledProcessError(1, ['ssh'])))
+    data = {'file': (BytesIO(b"Testing: \x00\x01"), 'test_file.png')}
+    response = client.post('/image', data=data) 
+    assert response.status_code == 400
+    assert b'Error: Failed to copy file to hosts' in response.data

--- a/tests/view_tests/test_image_routes.py
+++ b/tests/view_tests/test_image_routes.py
@@ -44,5 +44,5 @@ def test_post_image_route_copying_exception(monkeypatch, client):
     monkeypatch.setattr('subprocess.run', lambda command, check: raise_(CalledProcessError(1, ['ssh'])))
     data = {'file': (BytesIO(b"Testing: \x00\x01"), 'test_file.png')}
     response = client.post('/image', data=data) 
-    assert response.status_code == 400
+    assert response.status_code == 500
     assert b'Error: Failed to copy file to hosts' in response.data


### PR DESCRIPTION
This code should enable syncing the uploaded stimuli images to the other connected Pis. We don't have the Pis networked together yet so I wasn't able to test this on our actual hardware yet.

Authentication between the devices should be handled with public/private key auth so that we don't have to worry about passing in passwords and whatnot. I'll configure all of this next week when I set up the network hardware.