### PR TITLE
Update README documentation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,15 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+python:
+   version: 3.8
+   install:
+      - requirements: requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,6 +9,8 @@ version: 2
 sphinx:
   configuration: docs/conf.py
 
+formats: all
+
 python:
    version: 3.8
    install:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 CSE 5911 Capstone Project: Elephant Vending Machine in coordination with Cincinnati Zoo
 
 ![Python package](https://github.com/mknox1225/elephants_cse5911/workflows/Python%20package/badge.svg?branch=master)
-[![MIT license](https://img.shields.io/badge/License-MIT-blue.svg)](https://lbesson.mit-license.org/)
+[![MIT license](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/Kalafut-organization/elephants_cse5911/blob/master/LICENSE.md)
 [![codecov](https://codecov.io/gh/Kalafut-organization/elephants_cse5911/branch/master/graph/badge.svg)](https://codecov.io/gh/Kalafut-organization/elephants_cse5911)
 [![Documentation Status](https://readthedocs.org/projects/elephants-cse5911/badge/?version=latest)](https://elephants-cse5911.readthedocs.io/en/latest/?badge=latest)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ CSE 5911 Capstone Project: Elephant Vending Machine in coordination with Cincinn
 ![Python package](https://github.com/mknox1225/elephants_cse5911/workflows/Python%20package/badge.svg?branch=master)
 [![MIT license](https://img.shields.io/badge/License-MIT-blue.svg)](https://lbesson.mit-license.org/)
 [![codecov](https://codecov.io/gh/Kalafut-organization/elephants_cse5911/branch/master/graph/badge.svg)](https://codecov.io/gh/Kalafut-organization/elephants_cse5911)
-[![Documentation Status](https://readthedocs.org/projects/pip/badge/?version=stable)](http://pip.pypa.io/en/stable/?badge=stable)
+[![Documentation Status](https://readthedocs.org/projects/elephants-cse5911/badge/?version=latest)](https://elephants-cse5911.readthedocs.io/en/latest/?badge=latest)
 
 
 ## Setting up your virtual environment

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ CSE 5911 Capstone Project: Elephant Vending Machine in coordination with Cincinn
     * On Windows run `.venv\Scripts\activate.bat`
     * On Unix or MacOS run `source .venv/bin/activate`
     * To deactivate run `deactivate`
+    * NOTE: You will need to activate your virtual environment every time you close and reopen your terminal
 1. Use `pip install -r requirements.txt` to install all required dependencies
 
 ## Starting the application
@@ -42,6 +43,7 @@ CSE 5911 Capstone Project: Elephant Vending Machine in coordination with Cincinn
 1. Navigate to `docs` directory
 1. `make html` to build API documentation
 1. Open `index.html` under `docs/_build/html/` in a browser to view documentation
+    * The master branch documentation can be viewed on Read the Docs by clicking the "docs" badge at the top of this README  
 
 ## Known issues
 1. API documentation does not build properly in a Windows environment. Use Unix or MacOS to reliably build and view documentation.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ CSE 5911 Capstone Project: Elephant Vending Machine in coordination with Cincinn
 [![Documentation Status](https://readthedocs.org/projects/elephants-cse5911/badge/?version=latest)](https://elephants-cse5911.readthedocs.io/en/latest/?badge=latest)
 
 
-## Setting up your virtual environment
+## Setting up your virtual environment and installing dependencies
 1. Navigate to the root directory of this project
 1. Run `python3 -m venv .venv` to create a virtual environment
 1. Activate your virtual environment
@@ -27,19 +27,14 @@ CSE 5911 Capstone Project: Elephant Vending Machine in coordination with Cincinn
 1. `flask run`
 
 ## Test suite
-1. Install coverage.py with `pip install coverage`
-1. Install pytest with `pip install pytest`
-1. Install CodeCoverage with `pip install codecov`
 1. To execute the test suite run `coverage run -m pytest`
 1. To view coverage report after tests have been run use `coverage report`
 
 ## Linting
-1. Install pylint with `pip install pylint`
 1. Navigate to the root directory of this project
 1. To check your code style, run `pylint elephant_vending_machine`
 
 ## Build and view API documentation
-1. Install sphinx with `pip install -r requirements.txt`
 1. Navigate to `docs` directory
 1. `make html` to build API documentation
 1. Open `index.html` under `docs/_build/html/` in a browser to view documentation

--- a/README.md
+++ b/README.md
@@ -44,6 +44,3 @@ CSE 5911 Capstone Project: Elephant Vending Machine in coordination with Cincinn
 1. `make html` to build API documentation
 1. Open `index.html` under `docs/_build/html/` in a browser to view documentation
     * The master branch documentation can be viewed on Read the Docs by clicking the "docs" badge at the top of this README  
-
-## Known issues
-1. API documentation does not build properly in a Windows environment. Use Unix or MacOS to reliably build and view documentation.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# elephants_cse5911
-CSE 5911 Capstone Project: Elephant Vending Machine in coordination with Cincinnati Zoo
+# Elephant Vending Machine
+OSU CSE 5911 Capstone Project: Elephant Vending Machine in coordination with Cincinnati Zoo. Designed to facilitate automated behavioral psychology experiments.
 
 ![Python package](https://github.com/mknox1225/elephants_cse5911/workflows/Python%20package/badge.svg?branch=master)
 [![MIT license](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/Kalafut-organization/elephants_cse5911/blob/master/LICENSE.md)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ Babel==2.8.0
 certifi==2019.11.28
 chardet==3.0.4
 Click==7.0
+codecov==2.0.15
 coverage==5.0.3
 docutils==0.16
 Flask==1.1.1


### PR DESCRIPTION
This PR addresses #15 and a few other documentation updates:
* Fix docs badge redirect URL
* Clarify venv instructions so users know to activate whenever starting a new terminal session
* Move known issues from README to GitHub
* Fix license badge redirect URL
* Update requirements.txt and update instructions so users avoid redundant `pip install` commands