### PR TITLE
Add codecov upload to github actions.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [run]
-    source=elephants_cse5911
+source=elephant_vending_machine
 
 omit =
 	# Ignore all files in virtual environment

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -30,7 +30,9 @@ jobs:
         pip install coverage
         coverage run -m pytest
         coverage xml
+    steps:
     - name: Upload coverage to codecov
+    - uses: actions/checkout@master
       uses: codecov/codecov-action@v1.0.5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -29,3 +29,12 @@ jobs:
         pip install pytest
         pip install coverage
         coverage run -m pytest
+        coverage xml
+    - name: Upload coverage to codecov
+      uses: codecov.codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.xml
+        flags: unittests
+        yml: ./codecov.yml
+        fail_ci_if_error: true

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -31,7 +31,7 @@ jobs:
         coverage run -m pytest
         coverage xml
     - name: Upload coverage to codecov
-      uses: codecov.codecov-action@v1
+      uses: codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -22,17 +22,12 @@ jobs:
         pip install -r requirements.txt
     - name: Lint with pylint
       run: |
-        pip install pylint
         pylint elephant_vending_machine
     - name: Test with pytest and coverage
       run: |
-        pip install pytest
-        pip install coverage
         coverage run -m pytest
         coverage xml
-    steps:
-    - name: Upload coverage to codecov
-    - uses: actions/checkout@master
+    - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1.0.5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -31,7 +31,7 @@ jobs:
         coverage run -m pytest
         coverage xml
     - name: Upload coverage to codecov
-      uses: codecov-action@v1
+      uses: codecov/codecov-action@v1.0.5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml


### PR DESCRIPTION
Should hopefully resolve #14 by adding a github action to upload the coverage reports since GitHub actions are not a natively supported CICD option by codecov.